### PR TITLE
Delete dataset

### DIFF
--- a/frontend/src/app/dataset/dataset.component.html
+++ b/frontend/src/app/dataset/dataset.component.html
@@ -38,5 +38,12 @@ limitations under the License. -->
                 Timestamp Difference
             </mat-button-toggle>
         </mat-button-toggle-group>
+    <button [matMenuTriggerFor]="menu" mat-mini-fab color="primary" aria-label="Example icon button with a delete icon">
+        <mat-icon>delete</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+        <button mat-menu-item>Cancel</button>
+        <button mat-menu-item style="color: red;">Delete</button>
+      </mat-menu>
 </mat-expansion-panel>
 </mat-accordion>

--- a/frontend/src/app/dataset/dataset.component.html
+++ b/frontend/src/app/dataset/dataset.component.html
@@ -43,7 +43,8 @@ limitations under the License. -->
     </button>
     <mat-menu #menu="matMenu">
         <button mat-menu-item>Cancel</button>
-        <button mat-menu-item style="color: red;">Delete</button>
+        <button mat-menu-item style="color: red;" 
+            (click)="deleteDataset()">Delete</button>
       </mat-menu>
 </mat-expansion-panel>
 </mat-accordion>

--- a/frontend/src/app/dataset/dataset.component.html
+++ b/frontend/src/app/dataset/dataset.component.html
@@ -38,7 +38,7 @@ limitations under the License. -->
                 Timestamp Difference
             </mat-button-toggle>
         </mat-button-toggle-group>
-    <button [matMenuTriggerFor]="menu" mat-mini-fab color="primary" aria-label="Example icon button with a delete icon">
+    <button [matMenuTriggerFor]="menu" mat-mini-fab color="primary">
         <mat-icon>delete</mat-icon>
     </button>
     <mat-menu #menu="matMenu">

--- a/frontend/src/app/dataset/dataset.component.ts
+++ b/frontend/src/app/dataset/dataset.component.ts
@@ -62,7 +62,7 @@ export class DatasetComponent {
   }
 
   /**
-   * Setter method to initialize the dataset with a reference to itself. This enables
+   * Initializes the dataset with a reference to itself. This enables
    * the dataset to self-destruct when needed.
    * @param ref A reference to this component.
    */
@@ -78,8 +78,7 @@ export class DatasetComponent {
   }
 
   /**
-   * Responsible for removing all traces from plot
-   * and removing self from datasets list.
+   * Removes all traces from plot and removes self from dataset list.
    */
   deleteDataset() {
     console.log('Deleting myself...', this.ids.values());

--- a/frontend/src/app/dataset/dataset.component.ts
+++ b/frontend/src/app/dataset/dataset.component.ts
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 // Angular Imports.
-import {Component} from '@angular/core';
+import {Component, ComponentRef} from '@angular/core';
 
 // Project Imports.
 import {PlotComponent} from '../plot/plot.component';
@@ -26,6 +26,7 @@ import {PlotComponent} from '../plot/plot.component';
 export class DatasetComponent {
   sample: any;
   plotRef: PlotComponent;
+  containerRef: ComponentRef<DatasetComponent>;
   ids = new Map<any, number>();
   hasLatencies: boolean;
 
@@ -61,6 +62,14 @@ export class DatasetComponent {
   }
 
   /**
+   * Setter method to initialize the dataset with a reference to itself. This enables
+   * the dataset to self-destruct when needed.
+   * @param ref A reference to this component.
+   */
+  public setContainerRef(ref: ComponentRef<DatasetComponent>) {
+    this.containerRef = ref;
+  }
+  /**
    * Triggered when toggle on page is clicked. Calls the plot component toggleTrace method.
    * @param channel The channel of the trace to toggle.
    */
@@ -73,7 +82,8 @@ export class DatasetComponent {
    * and removing self from datasets list.
    */
   deleteDataset() {
-    console.log('Deleting myself...', this.ids.values()); //Array.from(this.ids.values()));
-    this.plotRef.deleteDataset(new Set<number>(this.ids.values())); //Array.from(this.ids.values()));
+    console.log('Deleting myself...', this.ids.values());
+    this.plotRef.deleteDataset(new Set<number>(this.ids.values()));
+    this.containerRef.destroy();
   }
 }

--- a/frontend/src/app/dataset/dataset.component.ts
+++ b/frontend/src/app/dataset/dataset.component.ts
@@ -67,4 +67,13 @@ export class DatasetComponent {
   toggleTrace(channel) {
     this.plotRef.toggleTrace(this.ids.get(channel));
   }
+
+  /**
+   * Responsible for removing all traces from plot
+   * and removing self from datasets list.
+   */
+  deleteDataset() {
+    console.log('Deleting myself...', this.ids.values()); //Array.from(this.ids.values()));
+    this.plotRef.deleteDataset(new Set<number>(this.ids.values())); //Array.from(this.ids.values()));
+  }
 }

--- a/frontend/src/app/plot/plot.component.ts
+++ b/frontend/src/app/plot/plot.component.ts
@@ -150,8 +150,7 @@ export class PlotComponent implements OnInit {
     let i = 0;
     while (i < this.plot_data.length) {
       if (ids.has(this.plot_data[i].id)) {
-        const deleted = this.plot_data.splice(i, 1);
-        console.log('deleted ', deleted, 'with id', deleted[0].id);
+        this.plot_data.splice(i, 1);
       } else {
         i++;
       }

--- a/frontend/src/app/plot/plot.component.ts
+++ b/frontend/src/app/plot/plot.component.ts
@@ -62,7 +62,7 @@ export class PlotComponent implements OnInit {
   message: any;
 
   // A map from id number to array index that will speed up toggle operations.
-  idMap = new Map<number, number>(); // TODO Handle when datasets are removed.
+  idMap = new Map<number, number>();
   constructor(private sharedService: UploadService) {}
 
   /**
@@ -140,5 +140,26 @@ export class PlotComponent implements OnInit {
   toggleTrace(id: number) {
     const index = this.idMap.get(id);
     this.plot_data[index].visible = !this.plot_data[index].visible;
+  }
+
+  /**
+   * Removes an entire dataset from plot_data.
+   * @param ids The individual traces to delete.
+   */
+  deleteDataset(ids: Set<number>) {
+    let i = 0;
+    while (i < this.plot_data.length) {
+      if (ids.has(this.plot_data[i].id)) {
+        const deleted = this.plot_data.splice(i, 1);
+        console.log('deleted ', deleted, 'with id', deleted[0].id);
+      } else {
+        i++;
+      }
+    }
+    // Reorder idMap with remaining traces and delete removed traces.
+    for (const i in this.plot_data) {
+      this.idMap.set(this.plot_data[i].id, Number(i));
+    }
+    ids.forEach(id => this.idMap.delete(id));
   }
 }

--- a/frontend/src/app/plot/plot.component.ts
+++ b/frontend/src/app/plot/plot.component.ts
@@ -146,10 +146,11 @@ export class PlotComponent implements OnInit {
    * Removes an entire dataset from plot_data.
    * @param ids The individual traces to delete.
    */
-  deleteDataset(ids: Set<number>) {
+  async deleteDataset(ids: Set<number>) {
     let i = 0;
     while (i < this.plot_data.length) {
       if (ids.has(this.plot_data[i].id)) {
+        // At index i, remove 1 element.
         this.plot_data.splice(i, 1);
       } else {
         i++;

--- a/frontend/src/app/upload.service.ts
+++ b/frontend/src/app/upload.service.ts
@@ -86,5 +86,6 @@ export class UploadService {
 
     compRef.instance.setSample(data);
     compRef.instance.setPlotRef(plotRef);
+    compRef.instance.setContainerRef(compRef);
   }
 }


### PR DESCRIPTION
Allows for the deletion of entire datasets from the app. A new trash button is included in the dataset menu, when clicked it confirms with the user if they want to delete the dataset. If yes, the dataset passes its ids to the plot.component, which then removes them completely from the plot. The dataset item component is then destroyed.